### PR TITLE
Correct Java JMI -> Java JNI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ libemojidex
 emojidex libraries in C++. 
 Built with portability in mind this library should easily enable back-end integration on desktop, 
 server and mobile platforms. 
-*Java JMI implementation coming soon!*
+*Java JNI implementation coming soon!*
 
 License
 =======


### PR DESCRIPTION
I suspect you mean JNI rather than JMI (Java Metadata interface), if you do mean JMI then just disregard this pull request.
